### PR TITLE
Validation element insertion breaks counter (because plugin is looking f...

### DIFF
--- a/jquery.charactercounter.js
+++ b/jquery.charactercounter.js
@@ -87,7 +87,7 @@
         function checkCount(element)
         {
             var characterCount = $(element).val().length;
-            var counter = options.counterSelector ? $(options.counterSelector) : $(element).next("." + options.counterCssClass);
+            var counter = options.counterSelector ? $(options.counterSelector) : $(element).siblings("." + options.counterCssClass);
             var remaining = options.limit - characterCount;
             var condition = remaining < 0;
 


### PR DESCRIPTION
...or $elem.next())
## Modifying the plugin to look for the counterCssClass among $elem siblings instead of $elem.next() - this way if validation inserts an extra label, span, etc. the plugin won't break.

I have a validation plugin that when triggered, unfortunately inserts a
label element directly after the <textarea> tag.  Since your plugin is
looking for the counter at $(<textarea).next() it breaks when the
counter is bumped down as the next sibling inline (even when using the
counterCssClass).
- An easy solution might be to change line #90 to use .siblings()
  instead of .next(), (or less desirable adding a counterID option).  
  I know this could potentially cause an issue if someone had multiple siblings with the
  same class name chosen for the counter but this seems like an odd/bad practice that would be easily rectified on their end.
- Many of the validation plugins I've used seem to follow this behavior
  so it might be a helpful fix for others.
